### PR TITLE
Test whether gofmt is happy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ install:
   - go get github.com/golang/dep/cmd/dep
   - dep ensure
 
+script:
+  - go test -v ./...
+  - '[ -z "$(gofmt -s -l .)" ] || { gofmt -s -d -e . ; return 1; } '
+
 matrix:
   allow_failures:
     - go: master


### PR DESCRIPTION
Tests will fail if the code is not `gofmt`ed.
Includes [the `-s` switch](https://golang.org/cmd/gofmt/#hdr-The_simplify_command).