### PR TITLE
Default port to 8800; added PORT configuration key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ LABEL \
 # Declare the port on which the webserver will be exposed.
 # As we're going to run the executable as an unprivileged user, we can't bind
 # to ports below 1024.
-EXPOSE 8080
+EXPOSE 8800
 
 # Perform any further action as an unprivileged user.
 USER nobody:nobody

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Apimock will remember the `Content-Type` associated with every request. This beh
 
 ## Docker container
 
-    docker run --name apimock -p 8800:80 -d pierreprinetti/apimock:latest
+    docker run --name apimock -p 8800:8800 -d pierreprinetti/apimock:latest
 
 ## Features
 

--- a/main.go
+++ b/main.go
@@ -42,7 +42,8 @@ func main() {
 	withCorsHeaders := newCors(apimock)
 	withLogging := newLogger(withCorsHeaders)
 
-	if err := http.ListenAndServe(getenv("HOST", ":80"), withLogging); err != nil {
+	if err := http.ListenAndServe(
+		getenv("HOST", ":"+getenv("PORT", "8800")), withLogging); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
As title says, this defaults the server to port 8800 and provides a new configuration key for specifying only the port.
Also fix Dockerfile.